### PR TITLE
Seperate Router from App component to allow root subscriptions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import { ThemeProvider } from "@emotion/react";
 import { CircularProgress, CssBaseline } from "@mui/material";
 import { createTheme } from "@mui/material/styles";
 import { createClient } from "graphql-ws";
-import { SnackbarProvider } from "notistack";
+import { SnackbarProvider, enqueueSnackbar } from "notistack";
 
 import { Admin, Error, Main, User } from "./components";
 import { useJWT } from "./hooks";
@@ -30,6 +30,7 @@ import {
   UserChecks,
   Users,
 } from "./pages";
+import { useGlobalNotificationSubscription } from "./graph";
 
 const LazyComponent = ({ element }: { element: ReactNode }): ReactElement => {
   return <Suspense fallback={<CircularProgress />}>{element}</Suspense>;
@@ -123,6 +124,19 @@ type props = {
 function Router({ theme, setTheme, apolloClient }: props) {
   const [cookies, setCookie, removeCookie] = useCookies(["auth", "admin"]);
   const jwt = useJWT(cookies.auth);
+
+  useGlobalNotificationSubscription({
+    onData: (data) => {
+      if (data.data.data?.globalNotification) {
+        enqueueSnackbar(data.data.data.globalNotification.message, {
+          variant: data.data.data.globalNotification.type,
+        });
+      }
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
 
   const router = createBrowserRouter([
     {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import { ReactElement, ReactNode, Suspense, useMemo, useState } from "react";
+import { useCookies } from "react-cookie";
+import { RouterProvider, createBrowserRouter } from "react-router-dom";
 
 import {
   ApolloClient,
@@ -15,19 +17,17 @@ import { CircularProgress, CssBaseline } from "@mui/material";
 import { createTheme } from "@mui/material/styles";
 import { createClient } from "graphql-ws";
 import { SnackbarProvider } from "notistack";
-import { useCookies } from "react-cookie";
-import { RouterProvider, createBrowserRouter } from "react-router-dom";
 
 import { Admin, Error, Main, User } from "./components";
 import { useJWT } from "./hooks";
 import {
+  AdminChecks,
   AdminPanel,
   ChangePassword,
-  AdminChecks,
-  UserChecks,
   Home,
   Login,
   Me,
+  UserChecks,
   Users,
 } from "./pages";
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,10 @@ import {
   UserChecks,
   Users,
 } from "./pages";
-import { useGlobalNotificationSubscription } from "./graph";
+import {
+  useEngineStateSubscription,
+  useGlobalNotificationSubscription,
+} from "./graph";
 
 const LazyComponent = ({ element }: { element: ReactNode }): ReactElement => {
   return <Suspense fallback={<CircularProgress />}>{element}</Suspense>;
@@ -138,6 +141,12 @@ function Router({ theme, setTheme, apolloClient }: props) {
     },
   });
 
+  const { data } = useEngineStateSubscription({
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+
   const router = createBrowserRouter([
     {
       path: "/",
@@ -152,6 +161,7 @@ function Router({ theme, setTheme, apolloClient }: props) {
               setCookie={setCookie}
               removeCookie={removeCookie}
               apolloClient={apolloClient}
+              engineState={data?.engineState}
             />
           }
         />
@@ -183,7 +193,11 @@ function Router({ theme, setTheme, apolloClient }: props) {
           children: [
             {
               index: true,
-              element: <LazyComponent element={<AdminPanel />} />,
+              element: (
+                <LazyComponent
+                  element={<AdminPanel engineState={data?.engineState} />}
+                />
+              ),
             },
             {
               path: "checks",

--- a/src/components/Admin/AdminPanel/EngineState.tsx
+++ b/src/components/Admin/AdminPanel/EngineState.tsx
@@ -3,18 +3,15 @@ import { enqueueSnackbar } from "notistack";
 
 import {
   EngineState,
-  useEngineStateSubscription,
   useStartEngineMutation,
   useStopEngineMutation,
 } from "../../../graph";
 
-export default function EngineStateComponent() {
-  const { data } = useEngineStateSubscription({
-    onError: (error) => {
-      console.error(error);
-    },
-  });
+type props = {
+  engineState: EngineState | undefined;
+};
 
+export default function EngineStateComponent({ engineState }: props) {
   const [StartEngine] = useStartEngineMutation({
     onError: (error) => {
       enqueueSnackbar(error.message, { variant: "error" });
@@ -51,16 +48,14 @@ export default function EngineStateComponent() {
         <Button
           variant='contained'
           color={
-            color[data?.engineState || "default"] as
+            color[engineState || "default"] as
               | "error"
               | "success"
               | "warning"
               | "info"
           }
         >
-          <Typography variant='h5'>
-            {data?.engineState || "disconnected"}
-          </Typography>
+          <Typography variant='h5'>{engineState || "disconnected"}</Typography>
         </Button>
 
         <Box sx={{ m: 2 }} />
@@ -70,9 +65,8 @@ export default function EngineStateComponent() {
               StartEngine();
             }}
             disabled={
-              !data ||
-              data.engineState === EngineState.Running ||
-              data.engineState === EngineState.Waiting
+              engineState === EngineState.Running ||
+              engineState === EngineState.Waiting
             }
           >
             <Typography variant='h6'>Start</Typography>
@@ -81,7 +75,7 @@ export default function EngineStateComponent() {
             onClick={() => {
               StopEngine();
             }}
-            disabled={!data || data.engineState === EngineState.Paused}
+            disabled={engineState === EngineState.Paused}
           >
             <Typography variant='h6'>Stop</Typography>
           </Button>

--- a/src/components/Core/Main.tsx
+++ b/src/components/Core/Main.tsx
@@ -5,9 +5,7 @@ import { CookieSetOptions } from "universal-cookie";
 import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
 import { Box, Container } from "@mui/material";
 
-import { enqueueSnackbar } from "notistack";
 import { Drawer, Navbar } from "..";
-import { useGlobalNotificationSubscription } from "../../graph";
 import { JWT } from "../../models";
 
 type props = {
@@ -40,20 +38,6 @@ export default function Main({
   apolloClient,
 }: props) {
   const [drawerState, setDrawerState] = useState(false);
-
-  useGlobalNotificationSubscription({
-    onData: (data) => {
-      if (data.data.data?.globalNotification) {
-        enqueueSnackbar(data.data.data.globalNotification.message, {
-          variant: data.data.data.globalNotification.type,
-        });
-      }
-    },
-    onError: (error) => {
-      console.error(error);
-    },
-  });
-
   return (
     <Box sx={{ minHeight: "100vh", backgroundColor: "default" }}>
       <Drawer

--- a/src/components/Core/Main.tsx
+++ b/src/components/Core/Main.tsx
@@ -7,6 +7,7 @@ import { Box, Container } from "@mui/material";
 
 import { Drawer, Navbar } from "..";
 import { JWT } from "../../models";
+import { EngineState } from "../../graph";
 
 type props = {
   theme: string;
@@ -26,6 +27,7 @@ type props = {
     options?: CookieSetOptions | undefined
   ) => void;
   apolloClient: ApolloClient<NormalizedCacheObject>;
+  engineState: EngineState | undefined;
 };
 
 export default function Main({
@@ -36,6 +38,7 @@ export default function Main({
   setCookie,
   removeCookie,
   apolloClient,
+  engineState,
 }: props) {
   const [drawerState, setDrawerState] = useState(false);
   return (
@@ -56,6 +59,7 @@ export default function Main({
         removeCookie={removeCookie}
         jwt={jwt}
         apolloClient={apolloClient}
+        engineState={engineState}
       />
       <Container component='main'>
         <Outlet />

--- a/src/components/Core/Navbar.tsx
+++ b/src/components/Core/Navbar.tsx
@@ -14,7 +14,7 @@ import {
 import { CookieSetOptions } from "universal-cookie";
 
 import { StatusIndicator } from "..";
-import { useEngineStateSubscription } from "../../graph";
+import { EngineState } from "../../graph";
 import { JWT } from "../../models";
 
 type props = {
@@ -31,6 +31,7 @@ type props = {
   ) => void;
   jwt: JWT;
   apolloClient: ApolloClient<NormalizedCacheObject>;
+  engineState: EngineState | undefined;
 };
 
 export default function Navbar({
@@ -40,14 +41,9 @@ export default function Navbar({
   removeCookie,
   jwt,
   apolloClient,
+  engineState,
 }: props) {
   const navigate = useNavigate();
-
-  const { data } = useEngineStateSubscription({
-    onError: (error) => {
-      console.error(error);
-    },
-  });
 
   return (
     <Box sx={{ flexGrow: 1 }}>
@@ -88,7 +84,7 @@ export default function Navbar({
             }}
           >
             <StatusIndicator
-              status={data?.engineState}
+              status={engineState}
               positiveTitle='Engine is Scoring'
               negativeTitle='Engine is Paused'
               sx={{ margin: "10px" }}

--- a/src/pages/Admin/AdminPanel.tsx
+++ b/src/pages/Admin/AdminPanel.tsx
@@ -3,9 +3,18 @@ import { useState } from "react";
 import { Box, Button, ButtonGroup, Container, Typography } from "@mui/material";
 
 import { useNavigate } from "react-router-dom";
-import { EngineState, Notification, StatusStream } from "../../components";
+import {
+  EngineState as EngineStateComponent,
+  Notification,
+  StatusStream,
+} from "../../components";
+import { EngineState } from "../../graph";
 
-export default function AdminPanel() {
+type props = {
+  engineState: EngineState | undefined;
+};
+
+export default function AdminPanel({ engineState }: props) {
   const navigate = useNavigate();
   const urlParams = new URLSearchParams(location.search);
 
@@ -20,7 +29,7 @@ export default function AdminPanel() {
 
   const components = {
     notification: <Notification />,
-    engine: <EngineState />,
+    engine: <EngineStateComponent engineState={engineState} />,
     status_stream: <StatusStream />,
   };
 


### PR DESCRIPTION
Seperate `Router` from `App` component in order to allow requests at root

Reorder imports

Moved global notification subscription handler into root

Add useEngineStateSubscription hook to App and pass engineState to AdminPanel and EngineStateComponent